### PR TITLE
IOW-724 add terminal errors to dashboard

### DIFF
--- a/persist_error/handler.py
+++ b/persist_error/handler.py
@@ -18,6 +18,7 @@ def lambda_handler(event, context):
     logger.info(f'Context: {context}')
 
     queue_url = os.getenv('AWS_SQS_QUEUE_URL')
+    terminal_queue_url = os.getenv('AWS_TERMINAL_QUEUE_URL')
     sns_arn = os.getenv('AWS_SNS_ARN')
     region = os.getenv('AWS_DEPLOYMENT_REGION')
     max_retries = int(os.getenv('MAX_RETRIES', 4))
@@ -78,5 +79,6 @@ def lambda_handler(event, context):
             f'Please take a closer look at the underlying records and data.'
         )
         resp = send_notification(sns_arn, failure_message, subject_line=subject,)
+        send_message(terminal_queue_url, failure_message)
         logger.info(f'Input failed more than {max_retries} times: {initial_input}. Notification sent to SNS: {resp}.')
     return initial_input

--- a/persist_error/tests/test_handler.py
+++ b/persist_error/tests/test_handler.py
@@ -3,7 +3,6 @@ Tests for the AWS Lambda handler.
 
 """
 import json
-import os
 from unittest import TestCase, mock
 import warnings
 

--- a/persist_error/tests/test_handler.py
+++ b/persist_error/tests/test_handler.py
@@ -13,11 +13,14 @@ from ..handler import lambda_handler
 class TestLambdaHandler(TestCase):
 
     queue_url = 'https://sqs.us-south-10.amazonaws.com/887501/some-queue-name'
+    terminal_queue_url = 'https://sqs.us-south-10.amazonaws.com/887501/some-terminal-queue-name'
+
     sns_arn = 'arn:aws:sns:us-south-23:5746521541:fake-notification'
     region = 'us-south-10'
     max_retries = 6
     mock_env_vars = {
         'AWS_SQS_QUEUE_URL': queue_url,
+        'AWS_TERMINAL_QUEUE_URL': terminal_queue_url,
         'AWS_SNS_ARN': sns_arn,
         'AWS_DEPLOYMENT_REGION': region,
         'MAX_RETRIES': str(max_retries)
@@ -114,7 +117,6 @@ class TestLambdaHandler(TestCase):
     @mock.patch('persist_error.handler.send_message', autospec=True)
     @mock.patch('persist_error.handler.send_notification', autospec=True)
     def test_terminal_failure_behavior(self, mock_sn, mock_sm):
-        os.environ['AWS_TERMINAL_QUEUE_URL'] = 'terminal_queue'
 
         lambda_handler(self.terminal_fail_event, self.context)
         expected_output = {
@@ -134,7 +136,7 @@ class TestLambdaHandler(TestCase):
             f'Please take a closer look at the underlying records and data.'
         )
         mock_sm.assert_called_once_with(
-            'terminal_queue',
+            self.terminal_queue_url,
             'Step function execution arn:aws:states:us-south-10:98877654311:blah:i3m556d-b5903fe has terminally failed. \nThe file we attempted to process: json file could not be parsed from state machine input, no s3 url generated \nThis input has exceeded 6 failures:\n{\n    "Record": {\n        "eventVersion": "2.1",\n        "eventSource": "aws:s3"\n    },\n    "previousExecutions": [\n        "arn:aws:states:us-south-10:98877654311:blah:a17h83j-p84321",\n        "arn:aws:states:us-south-10:98877654311:blah:ab423cf-7753ae",\n        "arn:aws:states:us-south-10:98877654311:blah:i3m556d-b5903fe"\n    ],\n    "stepFunctionFails": 7\n}.\nPlease take a closer look at the underlying records and data.'
         )
         mock_sn.assert_called_with(
@@ -147,7 +149,6 @@ class TestLambdaHandler(TestCase):
     @mock.patch('persist_error.handler.send_message', autospec=True)
     @mock.patch('persist_error.handler.send_notification', autospec=True)
     def test_terminal_failure_behavior_with_json_file(self, mock_sn, mock_sm):
-        os.environ['AWS_TERMINAL_QUEUE_URL'] = 'terminal_queue'
         with warnings.catch_warnings(record=True) as w:
             lambda_handler(self.terminal_fail_event_with_json_file, self.context)
             # test warning behavior
@@ -182,7 +183,7 @@ class TestLambdaHandler(TestCase):
                 f'Please take a closer look at the underlying records and data.'
             )
             mock_sm.assert_called_once_with(
-                'terminal_queue',
+                self.terminal_queue_url,
                 'Step function execution arn:aws:states:us-south-10:98877654311:blah:i3m556d-b5903fe has terminally failed. \nThe file we attempted to process: https://s3.console.aws.amazon.com/s3/object/iow-retriever-capture-dev?region=us-south-10&prefix=body_getTSData_3408_7664109d-4bf5-42eb-bb84-9505cd79137f.json \nThis input has exceeded 6 failures:\n{\n    "Record": {\n        "eventVersion": "2.1",\n        "eventSource": "aws:s3",\n        "s3": {\n            "bucket": {\n                "name": "iow-retriever-capture-dev"\n            },\n            "object": {\n                "key": "body_getTSData_3408_7664109d-4bf5-42eb-bb84-9505cd79137f.json"\n            }\n        }\n    },\n    "previousExecutions": [\n        "arn:aws:states:us-south-10:98877654311:blah:a17h83j-p84321",\n        "arn:aws:states:us-south-10:98877654311:blah:ab423cf-7753ae",\n        "arn:aws:states:us-south-10:98877654311:blah:i3m556d-b5903fe"\n    ],\n    "stepFunctionFails": 7\n}.\nPlease take a closer look at the underlying records and data.'
             )
             mock_sn.assert_called_with(

--- a/serverless.yml
+++ b/serverless.yml
@@ -132,7 +132,7 @@ resources:
       Properties:
         QueueName: aqts-capture-error-queue-${self:provider.stage}
         MessageRetentionPeriod: 1209600
-    terminalErrorQueue:
+    terminalErrorsQueue:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: aqts-capture-terminal-errors-queue-${self:provider.stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -58,6 +58,8 @@ functions:
     environment:
       AWS_SQS_QUEUE_URL:
         Ref: errorPersistQueue
+      AWS_TERMINAL_QUEUE_URL:
+        Ref: terminalErrorsQueue
       AWS_SNS_ARN:
         Ref: snsTopic
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
@@ -130,6 +132,11 @@ resources:
       Properties:
         QueueName: aqts-capture-error-queue-${self:provider.stage}
         MessageRetentionPeriod: 1209600
+    terminalErrorQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: aqts-capture-terminal-errors-queue-${self:provider.stage}
+        MessageRetentionPeriod: 345600
 
 plugins:
   - serverless-plugin-git-variables


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Add terminal errors to a terminal errors queue, in preparation for displaying on the dashboard.  Have the errors in the terminal queue persist for 4 days.

Description
-----------
If no JIRA ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
